### PR TITLE
Add PortAudio output support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -36,6 +36,10 @@ Build for Linux with ALSA:
 
 	$ make ALSA=1 psgplay
 
+Build for Linux or Mac OS with PortAudio:
+
+	$ make PORTAUDIO=1 psgplay
+
 Build for the Atari ST:
 
 	$ make TARGET_COMPILE=m68k-elf- PSGPLAY.TOS

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ so clone it with the `--recurse-submodules` option, or do
 
 For Linux and Mac OS, do `make psgplay` to compile `psgplay`. To use
 [Advanced Linux Sound Architecture](https://en.wikipedia.org/wiki/Advanced_Linux_Sound_Architecture)
-(ALSA) and _interactive text mode_, do `make ALSA=1 psgplay`.
+(ALSA) and _interactive text mode_, do `make ALSA=1 psgplay`. To use
+[PortAudio](https://portaudio.com)(PORTAUDIO) and _interactive text mode_,
+do `make PORTAUDIO=1 psgplay`.
+
 
 For Atari ST, do `make TARGET_COMPILE=m68k-elf- PSGPLAY.TOS`.
 
@@ -113,11 +116,10 @@ Tracing options:
 
 ## Interactive text mode
 
-PSG play defaults to _interactive text mode_ if it is compiled with ALSA
-for Linux, or is compiled for Atari ST. Mac OS does not support
-_interactive text mode_, only _command mode_ with
-[WAVE](https://en.wikipedia.org/wiki/WAV) format output,
-as described in issue [#8](https://github.com/frno7/psgplay/issues/8).
+PSG play defaults to _interactive text mode_ if it is compiled with either ALSA
+or PortAudio for Linux or MacOS, or is compiled for Atari ST. If no audio
+output support is present, PSG play will default to
+[WAVE](https://en.wikipedia.org/wiki/WAV) format output.
 
 For Linux, [TTY](https://en.wikipedia.org/wiki/Tty_(Unix)) mode and
 [ECMA-48](https://en.wikipedia.org/wiki/ANSI_escape_code) are used,
@@ -151,7 +153,7 @@ A cursor is shown with `>`. Keyboard controls:
 ## Command mode
 
 PSG play runs in _command mode_ if it is not compiled with ALSA for Linux,
-or is compiled for Mac OS, or the options `-o`, `--output`, `--start`,
+or with PortAudio for Linux or Mac OS, or the options `-o`, `--output`, `--start`,
 `--stop`, `--length`, `--disassemble` or `--trace` are given. Atari ST
 does not support _command mode_.
 

--- a/doc/psgplay.1
+++ b/doc/psgplay.1
@@ -64,8 +64,7 @@ separated with a colon, and optionally subseconds.
 .TP
 .BR \-m ", " \-\-mode "=<" \fIcommand\fR "|" \fItext\fR ">"
 \fIPSG play\fR defaults to \fIinteractive text mode\fR if it is compiled
-with ALSA for Linux. Mac OS does not support interactive text mode, only
-\fIcommand mode\fR with WAVE format output.
+with either ALSA for Linux or PortAudio for Linux or MacOS.
 
 .TP
 .BR \-t ", " \-\-track "=<" \fInumber\fR ">"
@@ -142,8 +141,8 @@ The SNDH file is loaded in memory at address 4000 (in hexadecimal).
 .RE
 
 .SH COMMAND MODE
-\fIPSG play\fR runs in command mode if it is not compiled with ALSA for
-Linux, or is compiled for Mac OS, or the options \fB-o\fR, \fB--output\fR,
+\fIPSG play\fR runs in command mode if it is not compiled with either ALSA for
+Linux, or PortAudio for Linux or Mac OS, or the options \fB-o\fR, \fB--output\fR,
 \fB--start\fR, \fB--stop\fR, \fB--length\fR, \fB--disassemble\fR or
 \fB--trace\fR are given. Atari ST does not support command mode.
 

--- a/include/out/portaudio.h
+++ b/include/out/portaudio.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef PSGPLAY_PORTAUDIO_H
+#define PSGPLAY_PORTAUDIO_H
+
+#include "out/output.h"
+
+extern const struct output portaudio_output;
+
+#endif /* PSGPLAY_PORTAUDIO_H */

--- a/lib/out/Makefile
+++ b/lib/out/Makefile
@@ -4,6 +4,12 @@ ifeq (1,$(ALSA))
 HAVE_CFLAGS += -DHAVE_ALSA
 endif
 
+ifeq (1,$(PORTAUDIO))
+HAVE_CFLAGS += -DHAVE_PORTAUDIO
+endif
+
+
 OUT_SRC := $(addprefix lib/out/,					\
 	   alsa.c							\
+	   portaudio.c				\
 	   wave.c)

--- a/lib/out/portaudio.c
+++ b/lib/out/portaudio.c
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2019 Fredrik Noring
+ * Copyright (C) 2025 Kåre Andersen
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "out/portaudio.h"
+
+#ifdef HAVE_PORTAUDIO
+
+#include <portaudio.h>
+
+#include "internal/assert.h"
+#include "internal/compare.h"
+#include "internal/fifo.h"
+#include "internal/print.h"
+
+#include "system/unix/file.h"
+#include "system/unix/memory.h"
+
+#define PORTAUDIO_BUFFER_SIZE 4096
+
+#define PORTAUDIO_SAMPLE(s) ((struct portaudio_sample) { .lo = (s), .hi = (s) >> 8 })
+
+struct portaudio_sample {
+	u8 lo;
+	s8 hi;
+};
+
+struct portaudio_stereo_sample {
+	struct portaudio_sample left;
+	struct portaudio_sample right;
+};
+
+struct portaudio_state {
+	bool nonblocking;
+	const char *output;
+
+	PaStream *stream;
+
+	int frequency;
+
+	struct portaudio_stereo_sample buffer[PORTAUDIO_BUFFER_SIZE];
+	struct fifo fifo;
+};
+
+static void portaudio_sample_flush(struct portaudio_state *state)
+{
+	PaError err;
+
+	if(Pa_IsStreamStopped(state->stream)) return;
+
+	if (fifo_empty(&state->fifo)) return;
+
+	const struct portaudio_stereo_sample *buffer;
+	const size_t r = fifo_peek(&state->fifo,
+		(const void **)&buffer);
+
+	BUG_ON(!r);
+	BUG_ON(r % sizeof(*buffer));
+
+	const ssize_t write_count = r / sizeof(*buffer);
+	err = Pa_WriteStream(state->stream, buffer, write_count);
+	if (err != paNoError)
+		pr_fatal_error("PortAudio Pa_WriteStream failed: %s",
+			Pa_GetErrorText(err));
+
+	fifo_skip(&state->fifo, write_count * sizeof(*buffer));
+}
+
+static bool portaudio_sample(s16 left, s16 right, void *arg)
+{
+	struct portaudio_state *state = arg;
+
+	if (fifo_full(&state->fifo)) {
+		portaudio_sample_flush(state);
+		return false;
+	}
+
+	const struct portaudio_stereo_sample stereo_sample = {
+		.left  = PORTAUDIO_SAMPLE(left),
+		.right = PORTAUDIO_SAMPLE(right)
+	};
+
+	const size_t w = fifo_write(&state->fifo,
+		&stereo_sample, sizeof(stereo_sample));
+
+	BUG_ON(w != sizeof(stereo_sample));
+
+	if (fifo_full(&state->fifo))
+		portaudio_sample_flush(state);
+
+	return true;
+}
+
+static bool portaudio_pause(void *arg)
+{
+	struct portaudio_state *state = arg;
+	PaError err;
+
+	if (Pa_IsStreamStopped(state->stream)) return true;
+
+	err = Pa_StopStream(state->stream);
+	if (err != paNoError)
+		pr_fatal_error("PortAudio Pa_StopStream failed: %s\n",
+			Pa_GetErrorText(err));
+
+	return true;
+}
+
+static bool portaudio_resume(void *arg)
+{
+	struct portaudio_state *state = arg;
+	PaError err;
+
+	err = Pa_StartStream(state->stream);
+	if (err != paNoError)
+		pr_fatal_error("PortAudio Pa_StartStream failed: %s\n",
+			Pa_GetErrorText(err));
+
+	return true;
+}
+
+static void portaudio_flush(void *arg)
+{
+	struct portaudio_state *state = arg;
+
+	while (!fifo_empty(&state->fifo))
+		portaudio_sample_flush(state);
+}
+
+static void portaudio_drop(void *arg)
+{
+	struct portaudio_state *state = arg;
+	PaError err;
+
+	fifo_clear(&state->fifo);
+
+	if (Pa_IsStreamStopped(state->stream)) return;
+
+	err = Pa_AbortStream(state->stream);
+
+	if (err != paNoError)
+		pr_fatal_error("PortAudio Pa_AbortStream failed: %s\n",
+			Pa_GetErrorText(err));
+}
+
+static void *portaudio_open(const char *output, int frequency, bool nonblocking)
+{
+	PaStreamParameters params;
+	PaStream *stream;
+	PaError err;
+
+	err = Pa_Initialize();
+	if (err != paNoError) goto error;
+
+	params.device = Pa_GetDefaultOutputDevice();
+	if (params.device == paNoDevice)
+		pr_fatal_error("PortAudio error: No default output device detected.\n");
+
+	params.channelCount = 2;
+	params.sampleFormat = paInt16;
+	params.suggestedLatency =
+		Pa_GetDeviceInfo(params.device)->defaultLowOutputLatency;
+	params.hostApiSpecificStreamInfo = NULL;
+
+	err = Pa_OpenStream(&stream, NULL, &params, frequency, 4096, paClipOff, NULL, NULL);
+	if (err != paNoError) goto error;
+
+	struct portaudio_state *state = xmalloc(sizeof(struct portaudio_state));
+	*state = (struct portaudio_state) {
+		.nonblocking = nonblocking,
+		.output = output,
+		.stream = stream,
+		.frequency = frequency,
+		.fifo = {
+			.capacity = sizeof(state->buffer),
+			.buffer = state->buffer
+		},
+	};
+
+	err = Pa_StartStream(state->stream);
+	if (err != paNoError) goto error;
+
+	return state;
+
+error:
+	pr_fatal_error("Error initializing PortAudio: %s\n", Pa_GetErrorText(err));
+}
+
+static void portaudio_close(void *arg)
+{
+	struct portaudio_state *state = arg;
+	PaError err;
+
+	portaudio_sample_flush(state);
+
+	if (!Pa_IsStreamStopped(state->stream)) {
+		err = Pa_StopStream(state->stream);
+		if (err != paNoError) goto error;
+	}
+
+	free(state);
+
+	err = Pa_Terminate();
+	if (err == paNoError) return;
+
+error:
+	pr_fatal_error("Error shutting down PortAudio: %s\n", Pa_GetErrorText(err));
+}
+
+#endif /* HAVE_PORTAUDIO */
+
+const struct output portaudio_output = {
+#ifdef HAVE_PORTAUDIO
+	.open	= portaudio_open,
+	.sample	= portaudio_sample,
+	.pause	= portaudio_pause,
+	.resume	= portaudio_resume,
+	.flush	= portaudio_flush,
+	.drop	= portaudio_drop,
+	.close	= portaudio_close,
+#endif /* HAVE_PORTAUDIO */
+};

--- a/lib/out/portaudio.c
+++ b/lib/out/portaudio.c
@@ -151,7 +151,7 @@ static void portaudio_drop(void *arg)
 
 static void *portaudio_open(const char *output, int frequency, bool nonblocking)
 {
-	PaStreamParameters params;
+	PaStreamParameters params = { };
 	PaStream *stream;
 	PaError err;
 

--- a/lib/out/portaudio.c
+++ b/lib/out/portaudio.c
@@ -168,7 +168,8 @@ static void *portaudio_open(const char *output, int frequency, bool nonblocking)
 		Pa_GetDeviceInfo(params.device)->defaultLowOutputLatency;
 	params.hostApiSpecificStreamInfo = NULL;
 
-	err = Pa_OpenStream(&stream, NULL, &params, frequency, 4096, paClipOff, NULL, NULL);
+	err = Pa_OpenStream(&stream, NULL, &params, frequency, PORTAUDIO_BUFFER_SIZE,
+		paClipOff, NULL, NULL);
 	if (err != paNoError) goto error;
 
 	struct portaudio_state *state = xmalloc(sizeof(struct portaudio_state));

--- a/system/unix/Makefile
+++ b/system/unix/Makefile
@@ -52,6 +52,14 @@ PSGPLAY_ALSA_LIB := $(shell pkg-config --silence-errors --libs alsa || echo -las
 PSGPLAY_LIBS += $(PSGPLAY_ALSA_LIB)
 endif
 
+ifeq (1,$(PORTAUDIO))
+PSGPLAY_PORTAUDIO_LIB := $(shell pkg-config --silence-errors --libs portaudio-2.0)
+PSGPLAY_PORTAUDIO_CFLAGS := $(shell pkg-config --silence-errors --cflags portaudio-2.0)
+PSGPLAY_CFLAGS += $(PSGPLAY_PORTAUDIO_CFLAGS)
+PSGPLAY_LIBS += $(PSGPLAY_PORTAUDIO_LIB)
+endif
+
+
 $(PSGPLAY): $(PSGPLAY_OBJ) $(LIBPSGPLAY_STATIC)
 	$(QUIET_LINK)$(HOST_CC) $(PSGPLAY_CFLAGS) -o $@ $^ $(PSGPLAY_LIBS)
 

--- a/system/unix/Makefile
+++ b/system/unix/Makefile
@@ -53,8 +53,8 @@ PSGPLAY_LIBS += $(PSGPLAY_ALSA_LIB)
 endif
 
 ifeq (1,$(PORTAUDIO))
-PSGPLAY_PORTAUDIO_LIB := $(shell pkg-config --silence-errors --libs portaudio-2.0)
-PSGPLAY_PORTAUDIO_CFLAGS := $(shell pkg-config --silence-errors --cflags portaudio-2.0)
+PSGPLAY_PORTAUDIO_LIB := $(shell pkg-config --libs portaudio-2.0)
+PSGPLAY_PORTAUDIO_CFLAGS := $(shell pkg-config --cflags portaudio-2.0)
 PSGPLAY_CFLAGS += $(PSGPLAY_PORTAUDIO_CFLAGS)
 PSGPLAY_LIBS += $(PSGPLAY_PORTAUDIO_LIB)
 endif

--- a/system/unix/psgplay.c
+++ b/system/unix/psgplay.c
@@ -15,6 +15,7 @@
 #include "psgplay/sndh.h"
 
 #include "out/alsa.h"
+#include "out/portaudio.h"
 #include "out/wave.h"
 
 #include "system/unix/command-mode.h"
@@ -91,6 +92,12 @@ static void select_subtune(int *track, struct file file)
 
 static const struct output *select_output(const struct options *options)
 {
+#ifdef HAVE_PORTAUDIO
+	if (!options->output) {
+		return &portaudio_output;
+  }
+#endif /* HAVE_PORTAUDIO */
+
 	if (alsa_output_handle(options->output)) {
 #ifdef HAVE_ALSA
 		return &alsa_output;


### PR DESCRIPTION
Here is code to support output over PortAudio. It should allow users to listen to SNDH tracks in MacOS without having to deal with Core Audio. As a bonus, it should work on any operating system that has a PortAudio port, including Linux and even MS Windows... Hope you find it useful to keep upstream - please don't hesitate to ask for any changes!