### PR TITLE
MacOS enhancements for flexible toolchain and linker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.sndh
 *.o
 *.o.d
+*.dylib
 /GPATH
 /GRTAGS
 /GTAGS

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,45 @@ endif
 UNAME_S := $(shell uname -s)
 
 ifdef HOST_COMPILE
-HOST_CC = $(HOST_COMPILE)gcc
-HOST_AR = $(HOST_COMPILE)ar
+HOST_CC     = $(HOST_COMPILE)gcc
+HOST_AR     = $(HOST_COMPILE)ar
+HOST_RANLIB = $(RANLIB)
 else
-HOST_CC = $(CC)
-HOST_AR = $(AR)
-HOST_RANLIB ?= ranlib
+HOST_CC     = $(CC)
+HOST_AR     = $(AR)
+HOST_RANLIB = $(RANLIB)
 endif
 
+ifeq ($(HOST_COMPILE_TYPE),homebrew-gcc)
+
 ifeq ($(UNAME_S),Darwin)
-HOST_LD     := /usr/bin/clang
-HOST_RANLIB := /usr/bin/ranlib
+HOMEBREW_GCC := $(shell find -L $(shell brew --prefix)/bin -type f \
+	-name 'gcc-[0-9]*' 2>/dev/null | sort -Vr | head -n1)
+
+ifneq ($(HOMEBREW_GCC),)
+HOST_CC := $(HOMEBREW_GCC)
+HOST_LD := /usr/bin/clang
+
 else
-HOST_LD			= $(CC)
-HOST_RANLIB	= $(RANLIB)
+$(error HOST_COMPILE_TYPE=homebrew-gcc requested but gcc could not be found)
+endif
+endif
+endif
+
+HOST_AR     := $(AR)
+HOST_RANLIB := $(RANLIB)
+
+ifeq ($(UNAME_S),Darwin)
+HOST_AR     := /usr/bin/ar
+HOST_RANLIB := /usr/bin/ranlib
+endif
+
+ifndef HOST_LD
+ifeq ($(UNAME_S),Darwin)
+HOST_LD := /usr/bin/clang
+else
+HOST_LD := $(CC)
+endif
 endif
 
 ifdef TARGET_COMPILE

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifeq ($(UNAME_S),Darwin)
 HOST_LD     := /usr/bin/clang
 HOST_RANLIB := /usr/bin/ranlib
 else
-HOST_LD			= $(LD)
+HOST_LD			= $(CC)
 HOST_RANLIB	= $(RANLIB)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,23 @@ else
 BUILD_CC = $(CC)
 endif
 
+UNAME_S := $(shell uname -s)
+
 ifdef HOST_COMPILE
 HOST_CC = $(HOST_COMPILE)gcc
 HOST_AR = $(HOST_COMPILE)ar
 else
 HOST_CC = $(CC)
 HOST_AR = $(AR)
+HOST_RANLIB ?= ranlib
+endif
+
+ifeq ($(UNAME_S),Darwin)
+HOST_LD     := /usr/bin/clang
+HOST_RANLIB := /usr/bin/ranlib
+else
+HOST_LD			= $(LD)
+HOST_RANLIB	= $(RANLIB)
 endif
 
 ifdef TARGET_COMPILE

--- a/lib/out/Makefile
+++ b/lib/out/Makefile
@@ -10,5 +10,5 @@ endif
 
 OUT_SRC := $(addprefix lib/out/,					\
 	   alsa.c							\
-	   portaudio.c				\
+	   portaudio.c							\
 	   wave.c)

--- a/lib/out/Makefile
+++ b/lib/out/Makefile
@@ -10,5 +10,5 @@ endif
 
 OUT_SRC := $(addprefix lib/out/,					\
 	   alsa.c							\
-	   portaudio.c							\
+	   portaudio.c				\
 	   wave.c)

--- a/lib/psgplay/Makefile
+++ b/lib/psgplay/Makefile
@@ -39,15 +39,28 @@ endef
 $(foreach f,$(LIBPSGPLAY_SRC),$(eval $(call LIBPSGPLAY_target,$(f))))
 
 LIBPSGPLAY_STATIC := lib/psgplay/libpsgplay.a
-LIBPSGPLAY_SHARED := lib/psgplay/libpsgplay.so
+
+UNAME_S := $(shell uname -s)
 
 $(LIBPSGPLAY_STATIC): $(LIBPSGPLAY_OBJ)
 	$(QUIET_AR)$(HOST_AR) rcs $@ $^
+	@if [ "$(UNAME_S)" = "Darwin" ]; then $(HOST_RANLIB) $@; fi
 
+ifeq ($(UNAME_S),Darwin)
+LIBPSGPLAY_SOFLAGS = -dynamiclib -install_name @rpath/libpsgplay.$(PSGPLAY_VERSION_MAJOR).dylib
+LIBPSGPLAY_SHARED := lib/psgplay/libpsgplay.dylib
+else
 LIBPSGPLAY_SOFLAGS = -shared -Wl,-soname,libpsgplay.so.$(PSGPLAY_VERSION_MAJOR)
+LIBPSGPLAY_SHARED := lib/psgplay/libpsgplay.so
+endif
 
+ifeq ($(UNAME_S),Darwin)
+$(LIBPSGPLAY_SHARED): $(LIBPSGPLAY_OBJ)
+	$(QUIET_CC)$(HOST_CC) -v -dynamiclib -o $@ $^ -install_name @rpath/$(LIBPSGPLAY_SONAME_MAJOR)
+else
 $(LIBPSGPLAY_SHARED): $(LIBPSGPLAY_OBJ)
 	$(QUIET_CC)$(HOST_CC) $(LIBPSGPLAY_SOFLAGS) $(HOST_CFLAGS) -o $@ $^
+endif
 
 LIBPSGPLAY_PC := lib/psgplay/libpsgplay.pc
 
@@ -124,9 +137,9 @@ install-lib-static: $(LIBPSGPLAY_STATIC)
 .PHONY: install-lib-shared
 install-lib-shared: $(LIBPSGPLAY_SHARED)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(libdir)
-	$(INSTALL) $(LIBPSGPLAY_SHARED) $(DESTDIR)$(libdir)/libpsgplay.so.$(PSGPLAY_VERSION_MINOR)
-	ln -s libpsgplay.so.$(PSGPLAY_VERSION_MINOR) $(DESTDIR)$(libdir)/libpsgplay.so.$(PSGPLAY_VERSION_MAJOR)
-	ln -s libpsgplay.so.$(PSGPLAY_VERSION_MAJOR) $(DESTDIR)$(libdir)/libpsgplay.so
+	$(INSTALL) $(LIBPSGPLAY_SHARED) $(DESTDIR)$(libdir)/libpsgplay.$(SHLIB_EXT).$(PSGPLAY_VERSION_MINOR)
+	ln -s libpsgplay.$(SHLIB_EXT).$(PSGPLAY_VERSION_MINOR) $(DESTDIR)$(libdir)/libpsgplay.$(SHLIB_EXT).$(PSGPLAY_VERSION_MAJOR)
+	ln -s libpsgplay.$(SHLIB_EXT).$(PSGPLAY_VERSION_MAJOR) $(DESTDIR)$(libdir)/libpsgplay.$(SHLIB_EXT)
 
 .PHONY: install-pkg
 install-pkg: $(LIBPSGPLAY_PC)

--- a/system/unix/Makefile
+++ b/system/unix/Makefile
@@ -45,7 +45,11 @@ $(foreach f,$(PSGPLAY_SRC),$(eval $(call PSGPLAY_target,$(f))))
 
 ALL_OBJ += $(PSGPLAY_OBJ) system/unix/system-unix-disassemble.o
 
-PSGPLAY_LIBS = -lm
+ifeq ($(UNAME_S),Darwin)
+MATH_LIB =
+else
+MATH_LIB = -lm
+endif
 
 ifeq (1,$(ALSA))
 PSGPLAY_ALSA_LIB := $(shell pkg-config --silence-errors --libs alsa || echo -lasound)
@@ -60,7 +64,7 @@ PSGPLAY_LIBS += $(PSGPLAY_PORTAUDIO_LIB)
 endif
 
 $(PSGPLAY): $(PSGPLAY_OBJ) $(LIBPSGPLAY_STATIC)
-	$(QUIET_LINK)$(HOST_CC) $(PSGPLAY_CFLAGS) -o $@ $^ $(PSGPLAY_LIBS)
+	$(QUIET_LINK)$(HOST_LD) $(PSGPLAY_CFLAGS) -o $@ $^ $(PSGPLAY_LIBS)
 
 .PHONY: install-psgplay
 install-psgplay: $(PSGPLAY)

--- a/system/unix/Makefile
+++ b/system/unix/Makefile
@@ -46,9 +46,9 @@ $(foreach f,$(PSGPLAY_SRC),$(eval $(call PSGPLAY_target,$(f))))
 ALL_OBJ += $(PSGPLAY_OBJ) system/unix/system-unix-disassemble.o
 
 ifeq ($(UNAME_S),Darwin)
-MATH_LIB =
+PSGPLAY_LIBS =
 else
-MATH_LIB = -lm
+PSGPLAY_LIBS = -lm
 endif
 
 ifeq (1,$(ALSA))


### PR DESCRIPTION
These patches enables MacOS users to build psgplay with gcc (tested with homebrew) and clang. The end goal is to be able to use the tracer/disassembler and to be able to include it in third party application in the form of a Mach-O (shared) dylib. Some work remains for the disassembler to work properly, but probably best handled in its own scope. 

This feels like a lot of cruft, but hopefully does not disturb regular (linux) builds in any way. Any comments and change requests are very welcome.

Features:
- Force use of macOS system linker (/usr/bin/clang) and ranlib (required for valid .a archives)
- Avoid GNU binutils on macOS to prevent malformed archives and framework linking issues
- Conditionally set -lm only on non-macOS platforms
- Set correct extension based on build type (.dylib for MacOS, .so for regular builds)
- Add .dylib to .gitignore