### PR TITLE
Fix envelopes in empiric mixing mode

### DIFF
--- a/include/psgplay/stereo.h
+++ b/include/psgplay/stereo.h
@@ -44,11 +44,13 @@ ssize_t psgplay_read_stereo(struct psgplay *pp,
  * @arg: argument supplied to psgplay_digital_to_stereo_callback()
  */
 typedef void (*psgplay_digital_to_stereo_cb)(
+	struct psgplay *pp,
 	struct psgplay_stereo *stereo, const struct psgplay_digital *digital,
 	size_t count, void *arg);
 
 /**
  * psgplay_digital_to_stereo_empiric - empiric stereo mix of digital samples
+ * @pp: PSG play object
  * @stereo: stereo samples
  * @digital: digital samples
  * @count: number of stereo samples to transform into digital samples
@@ -56,17 +58,18 @@ typedef void (*psgplay_digital_to_stereo_cb)(
  *
  * YM2149 PSG channel mix, as measured on Atari ST hardware.
  */
-void psgplay_digital_to_stereo_empiric(struct psgplay_stereo *stereo,
+void psgplay_digital_to_stereo_empiric(struct psgplay *pp, struct psgplay_stereo *stereo,
 	const struct psgplay_digital *digital, size_t count, void *arg);
 
 /**
  * psgplay_digital_to_stereo_linear - linear stereo mix of digital samples
+ * @pp: PSG play object
  * @stereo: stereo samples
  * @digital: digital samples
  * @count: number of stereo samples to transform into digital samples
  * @arg: ignored, can be %NULL
  */
-void psgplay_digital_to_stereo_linear(struct psgplay_stereo *stereo,
+void psgplay_digital_to_stereo_linear(struct psgplay *pp, struct psgplay_stereo *stereo,
 	const struct psgplay_digital *digital, size_t count, void *arg);
 
 /**
@@ -88,7 +91,7 @@ struct psgplay_psg_stereo_balance {
  * @count: number of stereo samples to transform into digital samples
  * @arg: pointer to struct psgplay_psg_stereo_balance
  */
-void psgplay_digital_to_stereo_balance(struct psgplay_stereo *stereo,
+void psgplay_digital_to_stereo_balance(struct psgplay *pp, struct psgplay_stereo *stereo,
 	const struct psgplay_digital *digital, size_t count, void *arg);
 
 /**
@@ -105,12 +108,13 @@ struct psgplay_psg_stereo_volume {
 
 /**
  * psgplay_digital_to_stereo_volume - volume stereo mix of digital samples
+ * @pp: PSG play object
  * @stereo: stereo samples
  * @digital: digital samples
  * @count: number of stereo samples to transform into digital samples
  * @arg: pointer to struct psgplay_psg_stereo_volume
  */
-void psgplay_digital_to_stereo_volume(struct psgplay_stereo *stereo,
+void psgplay_digital_to_stereo_volume(struct psgplay *pp, struct psgplay_stereo *stereo,
 	const struct psgplay_digital *digital, size_t count, void *arg);
 
 /**

--- a/system/unix/text-mode.c
+++ b/system/unix/text-mode.c
@@ -67,13 +67,13 @@ struct tty_arg {
 	struct sample_mixer *sm;
 };
 
-void digital_to_stereo(struct psgplay_stereo *stereo,
+void digital_to_stereo(struct psgplay *pp, struct psgplay_stereo *stereo,
 	const struct psgplay_digital *digital, size_t count, void *arg)
 {
 	struct sample_mixer *sm = arg;
 
 	if (!sm->tm->volume) {
-		sm->cb(stereo, digital, count, sm->arg);
+		sm->cb(pp, stereo, digital, count, sm->arg);
 		return;
 	}
 
@@ -86,7 +86,7 @@ void digital_to_stereo(struct psgplay_stereo *stereo,
 		for (size_t i = 0; i < n; i++)
 			sm->buffer[i].mixer.volume.main = sm->tm->volume;
 
-		sm->cb(&stereo[k], sm->buffer, n, sm->arg);
+		sm->cb(pp, &stereo[k], sm->buffer, n, sm->arg);
 	}
 }
 


### PR DESCRIPTION
this pull request fixes issue #43.

- when psgplay is mixing the channels according to the empiric mixing mode, psgplay will now use the 5-bit internal volumes for mixing through the DAC table instead of 4-bit.
- the DAC table is now part of the psgplay struct and replaced by a 32x32x32 table. instead of being pre-generated, it is now generated by psgplay_build_volume_table(struct psgplay *pp) in psgplay_init(). the DAC table generator is imported directly from Hatari's codebase, function [`YM2149_BuildModelVolumeTable`](https://github.com/hatari/hatari/blob/2781746f96c730328057f43c1f79b3475dccfba9/src/sound.c#L565-L678). it has been imported in its entirety and left in place for future extensions (tunable parameters, updates to the DAC table generation, etc...)
- as a consequence, all callbacks now have a "struct psgplay *pp" argument, and now require a psgplay struct, even if they do not use it. all calls to the callbacks have been updated to reflect this. (why? originally, I tried passing the psgplay struct to the callback, but by the time the callback was called, the psgplay struct argument was NULL, and the empiric mixing callback would try to access the DAC table from a NULL pointer. i have no idea why it became NULL, because prior to the callback, it was not NULL. after many hours of trying to debug it, I gave up and decided passing the psgplay struct would be the least problematic solution.)