### PR TITLE
Fix compiling for x86_64-w64-mingw32

### DIFF
--- a/include/internal/macro.h
+++ b/include/internal/macro.h
@@ -3,6 +3,11 @@
 #ifndef INTERNAL_MACRO_H
 #define INTERNAL_MACRO_H
 
+#include <stdint.h>
+#ifndef INTPTR_MAX /* m68k-elf-gcc (atari-st) does not define the optional intptr_t and friends */
+# define intptr_t long
+#endif
+
 /* Macro definitions from the Linux kernel. */
 
 #define __ALIGN__MASK(x, mask) (((x) + (mask)) & ~(mask))
@@ -40,7 +45,8 @@
  * Glory to Martin Uecker <Martin.Uecker@med.uni-goettingen.de>
  */
 #define __is_constexpr(x) \
-	(sizeof(int) == sizeof(*(8 ? ((void *)((long)(x) * 0l)) : (int *)8)))
+	(sizeof(int) == sizeof(*(8 ? ((void *)((intptr_t)(x) * 0)) : (int *)8)))
+
 
 #define __no_side_effects(x, y) \
 		(__is_constexpr(x) && __is_constexpr(y))


### PR DESCRIPTION
Compiling with mingw produces MANY instances like this:
 ```
psgplay-git/lib/atari/device.c: In function ‘device_run’:
psgplay-git/include/internal/macro.h:42:39: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   42 |         (sizeof(int) == sizeof(*(8 ? ((void *)((long)(x) * 0l)) : (int *)8)))
      |                                       ^
psgplay-git/include/internal/macro.h:45:18: note: in expansion of macro ‘__is_constexpr’
   45 |                 (__is_constexpr(x) && __is_constexpr(y))
      |                  ^~~~~~~~~~~~~~
psgplay-git/include/internal/compare.h:13:39: note: in expansion of macro ‘__no_side_effects’
   13 |                 (__typecheck(x, y) && __no_side_effects(x, y))
      |                                       ^~~~~~~~~~~~~~~~~
psgplay-git/include/internal/compare.h:23:31: note: in expansion of macro ‘__safe_cmp’
   23 |         __builtin_choose_expr(__safe_cmp(x, y), \
      |                               ^~~~~~~~~~
psgplay-git/include/internal/compare.h:32:25: note: in expansion of macro ‘__careful_cmp’
   32 | #define min(x, y)       __careful_cmp(x, y, <)
      |                         ^~~~~~~~~~~~~
psgplay-git/lib/atari/device.c:182:41: note: in expansion of macro ‘min’
  182 |                         machine_slice = min(machine_slice,
      |   
 ```
 
 Verified with this small test program
```
#include <stdio.h>
#include <stdint.h>

#define __is_constexpr(x) \
        (sizeof(int) == sizeof(*(8 ? ((void *)((long)(x) * (uintptr_t)0l)) : (int *)(uintptr_t)8)))

int foo(void)
{
        return 10;
}

int a = 10;
int bar(void)
{
        return a;
}


int main(int argc, char *argv[])
{
        printf ("0: %d\n",  __is_constexpr(0));
        printf ("1: %d\n",  __is_constexpr(1));
        printf ("1+1: %d\n",  __is_constexpr(1+1));
        printf ("foo(): %d\n",  __is_constexpr(foo()));
        printf ("bar(): %d\n",  __is_constexpr(bar()));

        printf ("sizeof(int) is %d\n", (int)sizeof (int));
        printf ("sizeof(long int) is %d\n", (int)sizeof (long int));
        printf ("sizeof(long lont int) is %d\n", (int)sizeof (long long int));
        return 0;
}
```

Which produces this output (both without and with the fix)
**on x86_64-w64-mingw32:**
```
0: 1
1: 1
1+1: 1
foo(): 0
bar(): 0
sizeof(int) is 4
sizeof(long int) is 4
sizeof(long lont int) is 8
```
 
**on x86_64_linux:**
```
0: 1
1: 1
1+1: 1
foo(): 0
bar(): 0
sizeof(int) is 4
sizeof(long int) is 8
sizeof(long lont int) is 8
```

Same issue in lib/toslibc/include/internal/macro.h